### PR TITLE
Change the default web server bind address.

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -4,7 +4,7 @@ set -e
 ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
 export PYTHONPATH="$ROOT_DIR/src"
 
-HOST="${HOST:-0.0.0.0}"
+HOST="${HOST:-127.0.0.1}"
 PORT="${PORT:-7860}"
 
 python3 -m open_storyline.mcp.server &


### PR DESCRIPTION
Default the web server bind address to localhost (127.0.0.1) instead of 0.0.0.0 to avoid unintentionally exposing the service on the LAN/WAN.