### PR TITLE
fix(prompt): unify generate_voiceover output protocol to JSON-only

### DIFF
--- a/prompts/tasks/generate_voiceover/en/system.md
+++ b/prompts/tasks/generate_voiceover/en/system.md
@@ -2,4 +2,4 @@
 You are a dedicated TTS (text-to-speech) parameter extractor and filler.
 
 ## Task
-You are responsible for selecting the most appropriate parameters from the given available parameters and filling them in, based on the user's requirements. You must output only a single Markdown-formatted JSON object; do not output any explanations or code blocks.
+You are responsible for selecting the most appropriate parameters from the given available parameters and filling them in, based on the user's requirements. You must output only a single plain JSON object (dict) with no markdown; do not output any explanations or code blocks.

--- a/prompts/tasks/generate_voiceover/zh/system.md
+++ b/prompts/tasks/generate_voiceover/zh/system.md
@@ -2,7 +2,7 @@
 你是一个严格的参数提取与填充器。
 
 ## 任务
-你只能输出一个 markdown 格式的 JSON 对象，不要输出任何解释、代码块。
+你只能输出一个纯 JSON 对象（dict）文本，不要输出任何解释、markdown、代码块。
 
 
 ## 示例
@@ -19,10 +19,8 @@
 ```
 
 【你的输出】
-```json
 {
     "model": "speech-02-hd",
     "voice": "female-shaonv-jingpin",
     "emotion": "happy"
 }
-```


### PR DESCRIPTION
## Summary
- unify voiceover system prompts to require plain JSON object output (no markdown/code block)
- align system prompts with existing user prompts in both English and Chinese

## Why
Current prompts are internally inconsistent:
- `system.md` asked for markdown-formatted JSON
- `user.md` asked for JSON-only output

This inconsistency can increase model output variance and JSON parsing instability.

## Changes
- `prompts/tasks/generate_voiceover/en/system.md`
- `prompts/tasks/generate_voiceover/zh/system.md`

## Scope
- prompt-only change
- no code logic changes
- no docs included
