### PR TITLE
docs: add model download reminder and volume mapping to Docker instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,11 +192,16 @@ $env:PYTHONPATH="src"; python -m open_storyline.mcp.server
 docker pull openstoryline/openstoryline:v1.0.0
 ```
 
+> [!NOTE]
+>
+> Before starting the container, make sure to complete the model download in [3. Resource Download & Installation](#3-resource-download--installation).
+
 ### Start the Container
 ```
 docker run \
   -v $(pwd)/config.toml:/app/config.toml \
   -v $(pwd)/outputs:/app/outputs \
+  -v $(pwd)/.storyline:/app/.storyline \
   -p 7860:7860 \
   openstoryline/openstoryline:v1.0.0
 ```

--- a/README_zh.md
+++ b/README_zh.md
@@ -201,11 +201,16 @@ sh build_env.sh
 docker pull openstoryline/openstoryline:v1.0.0
 ```
 
+> [!NOTE]
+>
+> 启动镜像前，需要先完成 [3. 资源下载与依赖安装](#3-资源下载与依赖安装) 中的模型下载。
+
 ### 启动镜像
 ```
 docker run \
   -v $(pwd)/config.toml:/app/config.toml \
   -v $(pwd)/outputs:/app/outputs \
+  -v $(pwd)/.storyline:/app/.storyline \
   -p 7860:7860 \
   openstoryline/openstoryline:v1.0.0
 ```


### PR DESCRIPTION
- Add a note to the Docker startup section in README.md and README_zh.md reminding users to complete the model download before starting the container.

- Include volume mapping for the .storyline directory to ensure the container can access local model files.