### PR TITLE
fix(group_clips): adaptive output token budget and parse retry for large inputs

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -83,6 +83,14 @@ transnet_device = "cpu"
 sample_fps = 2.0                 # 每秒抽几帧 / Frames sampled per second
 max_frames = 64                  # 单clip抽帧上限兜底，避免长视频爆 token / Max frames per clip limit to prevent token overflow
 
+# ============= 镜头分组 / Clip Grouping =============
+[group_clips]
+base_max_tokens = 4096           # group_clips 基础输出 token 预算 / Base output token budget for group_clips
+tokens_per_clip = 48             # 每个 clip 额外 token 预算 / Extra output token budget per selected clip
+max_tokens_cap = 16384           # token 预算上限 / Upper bound of output token budget
+retry_token_step = 2048          # 每次重试增加的 token 预算 / Token increase per retry
+max_parse_retries = 2            # JSON 解析失败时重试次数 / Retry count when JSON parsing fails
+
 # ============= 文案模板 / Script Templates =============
 [script_template]
 script_template_dir = "./resource/script_templates"

--- a/src/open_storyline/config.py
+++ b/src/open_storyline/config.py
@@ -144,6 +144,13 @@ class UnderstandClipsConfig(ConfigBaseModel):
     sample_fps: float = 2.0
     max_frames: int = 64
 
+class GroupClipsConfig(ConfigBaseModel):
+    base_max_tokens: int = Field(default=4096, ge=256, description="Base max output token budget for group_clips")
+    tokens_per_clip: int = Field(default=48, ge=0, description="Additional output token budget per selected clip")
+    max_tokens_cap: int = Field(default=16384, ge=512, description="Upper bound of max output token budget")
+    retry_token_step: int = Field(default=2048, ge=256, description="Token increment for each retry")
+    max_parse_retries: int = Field(default=2, ge=0, le=5, description="Retry count when model output parsing fails")
+
 class RecommendScriptTemplateConfig(ConfigBaseModel):
     script_template_dir: Path = Field(..., description="Script template directory.")
     script_template_info_path: Path = Field(..., description="Script template meta info path.")
@@ -243,6 +250,7 @@ class Settings(ConfigBaseModel):
     search_media: PexelsConfig
     split_shots: SplitShotsConfig
     understand_clips: UnderstandClipsConfig
+    group_clips: GroupClipsConfig = Field(default_factory=GroupClipsConfig)
     script_template: RecommendScriptTemplateConfig
     generate_voiceover: GenerateVoiceoverConfig
     select_bgm: SelectBGMConfig


### PR DESCRIPTION
## Background
Issue #16 reports `group_clips` JSON output being truncated at fixed `max_tokens=4096`, causing parsing failure before `groups` is fully returned.

## Root Cause
- `group_clips` used a hard-coded output budget (`max_tokens=4096`).
- Output size grows with clip count and prompt requirements (`think` + detailed groups), so fixed budget is not stable for larger inputs.

## Changes
1. Added configurable `group_clips` runtime budget settings:
   - `base_max_tokens`
   - `tokens_per_clip`
   - `max_tokens_cap`
   - `retry_token_step`
   - `max_parse_retries`
2. Implemented adaptive token estimation in `GroupClipsNode`:
   - Initial budget = `base_max_tokens + clip_count * tokens_per_clip`
   - Bounded by `max_tokens_cap`
3. Added resilient retry path on LLM/JSON parse failure:
   - Retries with increased token budget
   - Appends compact-output constraints on retry to reduce verbose output
4. Kept backward compatibility:
   - `Settings.group_clips` now has a default factory, so old configs without `[group_clips]` still load.

## Files
- `src/open_storyline/nodes/core_nodes/group_clips.py`
- `src/open_storyline/config.py`
- `config.toml`

## Validation
- `python -m compileall src/open_storyline/config.py src/open_storyline/nodes/core_nodes/group_clips.py`
- `PYTHONPATH=src python -c "from open_storyline.config import load_settings; s=load_settings('config.toml'); print(s.group_clips.base_max_tokens)"`

## Impact
- Fixes truncation risk in large grouping cases.
- Makes token policy configurable and scalable instead of hard-coded.

Closes #16
