### PR TITLE
Fix session restore invariants: fail-closed on corrupted tool rows, redact config secrets, and type getSession errors

### DIFF
--- a/agent_fastapi.py
+++ b/agent_fastapi.py
@@ -3224,6 +3224,11 @@ async def ws_chat(ws: WebSocket, session_id: str):
 
                         new_messages: List[BaseMessage] = []
 
+                        # Guard first: sanitize protocol on sess.lc_messages before we build
+                        # the merged request list for astream.
+                        # This ensures astream always receives the sanitized structure.
+                        sess._sanitize_tool_protocol_in_lc_messages()
+
                         # Merge multiple SystemMessages into one to support LLMs
                         # that do not allow more than one system message.
                         _system_parts: List[str] = []
@@ -3242,9 +3247,6 @@ async def ws_chat(ws: WebSocket, session_id: str):
                         async def pump_agent():
                             nonlocal new_messages
                             try:
-                                # Guard: ensure the messages list won't violate tool protocol after restore.
-                                # This prevents provider-side 400 like: "Messages with role 'tool' must be a response..."
-                                sess._sanitize_tool_protocol_in_lc_messages()
                                 stream = sess.agent.astream(
                                     {"messages": _merged_messages},
                                     context=sess.client_context,

--- a/agent_fastapi.py
+++ b/agent_fastapi.py
@@ -1254,6 +1254,10 @@ class MediaStore:
                     pass
 
 
+class SessionStateUnavailableError(Exception):
+    """session_state.json exists but cannot be read or parsed (I/O or JSON). Callers should map to 503, not 404."""
+
+
 class ChatSession:
     """
     一个 session 的全部状态：
@@ -1599,13 +1603,29 @@ class ChatSession:
             return None
         try:
             with open(path, "r", encoding="utf-8") as f:
-                data = json.load(f)
-            if not isinstance(data, dict):
-                return None
-            sid_in_file = str(data.get("session_id") or "").strip()
-            if sid_in_file and sid_in_file != session_id:
-                return None
-        except Exception:
+                raw = f.read()
+            data = json.loads(raw)
+        except OSError as e:
+            logger.warning("session state read failed sid=%s path=%s err=%s", session_id, path, e)
+            raise SessionStateUnavailableError("read_error") from e
+        except json.JSONDecodeError as e:
+            logger.warning("session state json invalid sid=%s path=%s err=%s", session_id, path, e)
+            raise SessionStateUnavailableError("corrupt_json") from e
+
+        if not isinstance(data, dict):
+            logger.warning("session state not a dict sid=%s path=%s", session_id, path)
+            raise SessionStateUnavailableError("invalid_shape")
+
+        # Mismatch vs persisted session_id → not this resource (404). Do not use 503 here:
+        # 503 is reserved for read/parse failures (SessionStateUnavailableError).
+        sid_in_file = str(data.get("session_id") or "").strip()
+        if sid_in_file and sid_in_file != session_id:
+            logger.warning(
+                "session state session_id mismatch path=%s requested=%s file=%s (treating as not found)",
+                path,
+                session_id,
+                sid_in_file,
+            )
             return None
 
         sess = cls(session_id=session_id, cfg=cfg)
@@ -2110,7 +2130,10 @@ class SessionStore:
         if not _is_valid_session_id_hex(sid):
             return None
 
-        restored = ChatSession.load_from_state(sid, self.cfg)
+        try:
+            restored = ChatSession.load_from_state(sid, self.cfg)
+        except SessionStateUnavailableError:
+            raise
         if restored is None:
             return None
         try:
@@ -2126,7 +2149,10 @@ class SessionStore:
             return restored
 
     async def get_or_404(self, sid: str) -> ChatSession:
-        sess = await self.get(sid)
+        try:
+            sess = await self.get(sid)
+        except SessionStateUnavailableError as e:
+            raise HTTPException(status_code=503, detail="session state unavailable") from e
         if not sess:
             raise HTTPException(status_code=404, detail="session not found")
         return sess
@@ -2867,11 +2893,17 @@ async def ws_chat(ws: WebSocket, session_id: str):
         await ws.accept()
 
         store: SessionStore = app.state.sessions
-        sess = await store.get(session_id)
+        try:
+            sess = await store.get(session_id)
+        except SessionStateUnavailableError:
+            try:
+                await ws.close(code=1013, reason="session state unavailable")
+            except Exception:
+                pass
+            return
         if not sess:
             await ws.close(code=4404, reason="session not found")
             return
-        sess = await store.get_or_404(session_id)
 
         await ws_send(ws, "session.snapshot", sess.snapshot())
 

--- a/agent_fastapi.py
+++ b/agent_fastapi.py
@@ -1328,6 +1328,11 @@ class ChatSession:
         self._media_seq_inited = False
         self._media_seq_next = 1
 
+        # Restore diagnostics (not persisted). When recovery detects corrupt tool rows,
+        # we "fail-closed" by truncating lc_messages from the impacted tool-use turn.
+        self.restore_degraded: bool = False
+        self.restore_degraded_reason: str = ""
+
     @classmethod
     def state_file_path_for(cls, session_id: str, cfg: Settings) -> str:
         return os.path.abspath(os.path.join(str(cfg.project.outputs_dir), session_id, SESSION_STATE_FILENAME))
@@ -1376,6 +1381,80 @@ class ChatSession:
         if cfg_obj is None:
             return None
         return _mask_secrets_recursive(_to_json_safe(cfg_obj))
+
+    @staticmethod
+    def _sanitize_custom_model_cfg_for_state(cfg_obj: Any) -> Optional[Dict[str, Any]]:
+        """
+        Primary boundary for persistence: never serialize raw API keys for custom models.
+        Only keep {model, base_url, api_key="***"} and drop everything else.
+        """
+        if not isinstance(cfg_obj, dict) or not cfg_obj:
+            return None
+        model = _s(cfg_obj.get("model"))
+        base_url = _norm_url(cfg_obj.get("base_url"))
+        api_key_present = _s(cfg_obj.get("api_key"))
+        out: Dict[str, Any] = {"model": model, "base_url": base_url}
+        if api_key_present or any(_is_secret_field_name(str(k)) for k in cfg_obj.keys()):
+            out["api_key"] = MASKED_SECRET
+        return out
+
+    @staticmethod
+    def _sanitize_tts_cfg_for_state(tts_cfg: Any) -> Dict[str, Any]:
+        """
+        Primary boundary for persistence: keep TTS structure but redact secret fields by key name.
+        Regex-based masking still applies as a secondary fallback for string payloads.
+        """
+        if not isinstance(tts_cfg, dict) or not tts_cfg:
+            return {}
+        safe = _mask_secrets_recursive(_to_json_safe(tts_cfg))
+        return safe if isinstance(safe, dict) else {}
+
+    def _fail_closed_truncate_lc_messages(self, truncate_at: int, reason: str) -> None:
+        truncate_at = int(max(0, truncate_at))
+        msgs = [m for m in (self.lc_messages or []) if isinstance(m, BaseMessage)]
+        if truncate_at < len(msgs):
+            self.lc_messages = msgs[:truncate_at]
+        self.restore_degraded = True
+        self.restore_degraded_reason = (reason or "degraded_restore").strip()
+
+    def _validate_tool_protocol_and_fail_closed(self) -> None:
+        """
+        Validate tool-call pairing on restored lc_messages and fail-closed on corruption.
+        We do NOT try to invent a ToolMessage for missing tool_call_id; instead we truncate
+        to the last clean boundary to avoid feeding semantically corrupted tool results to the LLM.
+        """
+        msgs: List[BaseMessage] = [m for m in (self.lc_messages or []) if isinstance(m, BaseMessage)]
+        pending_ids: Set[str] = set()
+        responded_ids: Set[str] = set()
+        tool_turn_start_idx: Optional[int] = None
+
+        for idx, m in enumerate(msgs):
+            if isinstance(m, AIMessage):
+                pending_ids = _tool_call_ids_from_ai_message_for_state(m)
+                responded_ids = set()
+                tool_turn_start_idx = idx if pending_ids else None
+                continue
+
+            if isinstance(m, ToolMessage):
+                tcid = str(getattr(m, "tool_call_id", "") or "").strip()
+                if not tcid:
+                    self._fail_closed_truncate_lc_messages(
+                        tool_turn_start_idx if tool_turn_start_idx is not None else idx,
+                        "degraded_restore: empty tool_call_id",
+                    )
+                    return
+                if (not pending_ids) or (tcid not in pending_ids) or (tcid in responded_ids):
+                    self._fail_closed_truncate_lc_messages(
+                        tool_turn_start_idx if tool_turn_start_idx is not None else idx,
+                        "degraded_restore: tool protocol mismatch",
+                    )
+                    return
+                responded_ids.add(tcid)
+                continue
+
+            pending_ids = set()
+            responded_ids = set()
+            tool_turn_start_idx = None
 
     @staticmethod
     def _normalized_lc_messages_for_state(messages: List[BaseMessage], lang: str) -> List[BaseMessage]:
@@ -1457,9 +1536,10 @@ class ChatSession:
             "pending_media_ids": [str(x) for x in (self.pending_media_ids or [])],
             "lc_messages_serialized": self._serialize_lc_messages(),
             "pexels_key_mode": self.pexels_key_mode,
-            "custom_llm_config": self._sanitize_service_cfg_for_state(self.custom_llm_config),
-            "custom_vlm_config": self._sanitize_service_cfg_for_state(self.custom_vlm_config),
-            "tts_config": self._sanitize_service_cfg_for_state(self.tts_config),
+            # Primary boundary: never persist raw API keys for configs.
+            "custom_llm_config": self._sanitize_custom_model_cfg_for_state(self.custom_llm_config),
+            "custom_vlm_config": self._sanitize_custom_model_cfg_for_state(self.custom_vlm_config),
+            "tts_config": self._sanitize_tts_cfg_for_state(self.tts_config),
         }
 
     def save_state_atomic(self) -> None:
@@ -1643,16 +1723,30 @@ class ChatSession:
 
         lc_msgs_raw = data.get("lc_messages_serialized") or []
         lc_msgs: List[BaseMessage] = []
+        truncate_at: Optional[int] = None
+        truncate_reason: str = ""
+        last_tool_ai_idx: Optional[int] = None
         if isinstance(lc_msgs_raw, list):
             for item in lc_msgs_raw:
                 try:
+                    if isinstance(item, dict) and str(item.get("type") or "").strip().lower() == "tool":
+                        tcid_raw = str(item.get("tool_call_id") or "").strip()
+                        if not tcid_raw:
+                            truncate_at = last_tool_ai_idx if last_tool_ai_idx is not None else len(lc_msgs)
+                            truncate_reason = "degraded_restore: corrupt tool row (missing tool_call_id)"
+                            break
                     msg = _deserialize_lc_message(item)
                     if msg is not None:
+                        if isinstance(msg, AIMessage) and _tool_call_ids_from_ai_message_for_state(msg):
+                            last_tool_ai_idx = len(lc_msgs)
                         lc_msgs.append(msg)
                 except Exception:
                     continue
         sess.lc_messages = lc_msgs
         sess._ensure_lc_messages_invariants()
+        if truncate_at is not None:
+            sess._fail_closed_truncate_lc_messages(truncate_at, truncate_reason)
+            sess._ensure_lc_messages_invariants()
 
         sess.pexels_key_mode = str(data.get("pexels_key_mode") or "default").strip().lower()
         if sess.pexels_key_mode not in ("default", "custom"):
@@ -1667,6 +1761,8 @@ class ChatSession:
         sess.tts_config = tts_cfg if isinstance(tts_cfg, dict) else {}
 
         sess._normalize_running_tool_records()
+        sess._validate_tool_protocol_and_fail_closed()
+        sess._ensure_lc_messages_invariants()
         sess._close_unfinished_tool_calls_in_lc_messages()
         sess._sanitize_tool_protocol_in_lc_messages()
         sess._rebuild_tool_history_index()
@@ -1930,6 +2026,8 @@ class ChatSession:
             "pending_media": self.public_pending_media(),
             "history": self.history,
             "turn_running": self.chat_lock.locked(),
+            "restore_degraded": bool(getattr(self, "restore_degraded", False)),
+            "restore_degraded_reason": str(getattr(self, "restore_degraded_reason", "") or ""),
             "limits": {
                 "max_upload_files_per_request": MAX_UPLOAD_FILES_PER_REQUEST,
                 "max_media_per_session": MAX_MEDIA_PER_SESSION,

--- a/agent_fastapi.py
+++ b/agent_fastapi.py
@@ -319,11 +319,24 @@ _SECRET_VALUE_PATTERNS = [
     re.compile(r"(?i)(?:api[_-]?key|access[_-]?token|refresh[_-]?token|authorization)\s*[:=]\s*[\"']?[A-Za-z0-9._\-+/=]{16,}[\"']?"),
 ]
 
+# Inline `key: value` / `key=value` in plain strings: dict recursion masks by field name,
+# but the same secret in a single string only saw _SECRET_VALUE_PATTERNS (often 16+ chars).
+# Match unambiguous credential field names with shorter values (exclude bare "token"/"password"
+# which would false-positive in natural language).
+_SECRET_INLINE_ASSIGNMENT_RE = re.compile(
+    r"(?i)(?:api[_-]?key|api[_-]?token|auth[_-]?token|access[_-]?token|"
+    r"client[_-]?secret|refresh[_-]?token|x-api-key|apikey|access[_-]?key|accesskey|"
+    r"pexels[_-]?api[_-]?key)\s*[:=]\s*[\"']?"
+    r"[A-Za-z0-9._\-+/=]{3,}"
+    r"[\"']?"
+)
+
 
 def _mask_secret_string(text: str) -> str:
     s = str(text or "")
     for pat in _SECRET_VALUE_PATTERNS:
         s = pat.sub(MASKED_SECRET, s)
+    s = _SECRET_INLINE_ASSIGNMENT_RE.sub(MASKED_SECRET, s)
     return s
 
 
@@ -420,6 +433,10 @@ def _deserialize_lc_message(data: Dict[str, Any]) -> Optional[BaseMessage]:
     if t == "tool":
         tcid = str(data.get("tool_call_id") or "").strip()
         if not tcid:
+            logger.warning(
+                "Persisted ToolMessage skipped: empty tool_call_id. "
+                "If the preceding AI turn had tool_calls, load will synthesize cancelled tool results."
+            )
             return None
         kwargs: Dict[str, Any] = {}
         ak = data.get("additional_kwargs")

--- a/agent_fastapi.py
+++ b/agent_fastapi.py
@@ -1457,36 +1457,60 @@ class ChatSession:
             tool_turn_start_idx = None
 
     @staticmethod
-    def _normalized_lc_messages_for_state(messages: List[BaseMessage], lang: str) -> List[BaseMessage]:
+    def _apply_instruction_and_upload_headers(messages: List[BaseMessage], lang: str) -> List[BaseMessage]:
+        """
+        Single source of truth for lc_messages header invariants:
+        index 0 = instruction prompt for `lang`, index 1 = upload-status system message.
+        Strips any prior zh/en instruction prompts and re-hoists the first upload-status row
+        so language switches cannot leave duplicate instruction system messages in history.
+        """
         instruction_sys = get_prompt("instruction.system", lang=lang)
+        zh_ins = str(get_prompt("instruction.system", lang="zh")).strip()
+        en_ins = str(get_prompt("instruction.system", lang="en")).strip()
         upload_placeholder = UPLOAD_STATUS_SYSTEM_EMPTY
-        msgs: List[BaseMessage] = [m for m in (messages or []) if isinstance(m, BaseMessage)]
 
-        if not msgs:
-            return [SystemMessage(content=instruction_sys), SystemMessage(content=upload_placeholder)]
+        body: List[BaseMessage] = []
+        upload_msg: Optional[SystemMessage] = None
 
-        if not isinstance(msgs[0], SystemMessage) or str(getattr(msgs[0], "content", "")).strip() != str(instruction_sys).strip():
-            msgs.insert(0, SystemMessage(content=instruction_sys))
+        for m in messages or []:
+            if not isinstance(m, BaseMessage):
+                continue
+            if isinstance(m, SystemMessage):
+                c = str(getattr(m, "content", "")).strip()
+                if c == zh_ins or c == en_ins:
+                    continue
+                if c.startswith(UPLOAD_STATUS_SYSTEM_PREFIX):
+                    if upload_msg is None:
+                        upload_msg = m
+                    continue
+            body.append(m)
 
-        def _is_upload_stats_msg(m: BaseMessage) -> bool:
-            if not isinstance(m, SystemMessage):
-                return False
-            return str(getattr(m, "content", "")).strip().startswith(UPLOAD_STATUS_SYSTEM_PREFIX)
+        if upload_msg is None:
+            upload_msg = SystemMessage(content=upload_placeholder)
 
-        if len(msgs) == 1:
-            msgs.append(SystemMessage(content=upload_placeholder))
-        elif not _is_upload_stats_msg(msgs[1]):
-            found_idx = None
-            for i in range(2, len(msgs)):
-                if _is_upload_stats_msg(msgs[i]):
-                    found_idx = i
-                    break
-            if found_idx is not None:
-                m = msgs.pop(found_idx)
-                msgs.insert(1, m)
-            else:
-                msgs.insert(1, SystemMessage(content=upload_placeholder))
-        return msgs
+        return [SystemMessage(content=instruction_sys), upload_msg, *body]
+
+    @staticmethod
+    def _normalized_lc_messages_for_state(messages: List[BaseMessage], lang: str) -> List[BaseMessage]:
+        msgs = [m for m in (messages or []) if isinstance(m, BaseMessage)]
+        return ChatSession._apply_instruction_and_upload_headers(msgs, lang)
+
+    @staticmethod
+    def _safe_body_suffix_for_state(body: List[BaseMessage], budget: int) -> List[BaseMessage]:
+        """
+        Keep at most `budget` tail messages without starting at an orphan ToolMessage
+        (tool-turn left edge). Prefer preserving a shorter valid suffix over a longer invalid one.
+        """
+        n = len(body)
+        if budget <= 0 or n == 0:
+            return []
+        max_take = min(budget, n)
+        for take in range(max_take, 0, -1):
+            i = n - take
+            if isinstance(body[i], ToolMessage):
+                continue
+            return body[i:]
+        return []
 
     def _persist_history(self) -> List[Dict[str, Any]]:
         out: List[Dict[str, Any]] = []
@@ -1505,16 +1529,21 @@ class ChatSession:
 
     def _serialize_lc_messages(self) -> List[Dict[str, Any]]:
         msgs = self._normalized_lc_messages_for_state(list(self.lc_messages or []), self.lang)
-        if SESSION_STATE_MAX_LC_MESSAGES > 0 and len(msgs) > SESSION_STATE_MAX_LC_MESSAGES:
-            msgs = msgs[-SESSION_STATE_MAX_LC_MESSAGES:]
-            msgs = self._normalized_lc_messages_for_state(msgs, self.lang)
-            if len(msgs) > SESSION_STATE_MAX_LC_MESSAGES:
-                if SESSION_STATE_MAX_LC_MESSAGES <= 2:
-                    msgs = msgs[:SESSION_STATE_MAX_LC_MESSAGES]
+        cap = SESSION_STATE_MAX_LC_MESSAGES
+        if cap > 0 and len(msgs) > cap:
+            if cap <= 2:
+                msgs = msgs[:cap]
+            else:
+                head2 = msgs[:2]
+                tail = ChatSession._safe_body_suffix_for_state(msgs[2:], cap - 2)
+                msgs = self._normalized_lc_messages_for_state(head2 + tail, self.lang)
+            if len(msgs) > cap:
+                if cap <= 2:
+                    msgs = msgs[:cap]
                 else:
-                    # Keep invariant-critical first 2 system messages, trim tail payload.
-                    keep_tail = SESSION_STATE_MAX_LC_MESSAGES - 2
-                    msgs = msgs[:2] + msgs[-keep_tail:]
+                    head2 = msgs[:2]
+                    tail = ChatSession._safe_body_suffix_for_state(msgs[2:], cap - 2)
+                    msgs = self._normalized_lc_messages_for_state(head2 + tail, self.lang)
 
         out: List[Dict[str, Any]] = []
         for m in msgs:
@@ -1536,6 +1565,7 @@ class ChatSession:
             "pending_media_ids": [str(x) for x in (self.pending_media_ids or [])],
             "lc_messages_serialized": self._serialize_lc_messages(),
             "pexels_key_mode": self.pexels_key_mode,
+            "sent_media_total": int(getattr(self, "sent_media_total", 0) or 0),
             # Primary boundary: never persist raw API keys for configs.
             "custom_llm_config": self._sanitize_custom_model_cfg_for_state(self.custom_llm_config),
             "custom_vlm_config": self._sanitize_custom_model_cfg_for_state(self.custom_vlm_config),
@@ -1552,39 +1582,8 @@ class ChatSession:
         os.replace(tmp, path)
 
     def _ensure_lc_messages_invariants(self) -> None:
-        instruction_sys = get_prompt("instruction.system", lang=self.lang)
-        upload_placeholder = UPLOAD_STATUS_SYSTEM_EMPTY
-        msgs: List[BaseMessage] = [m for m in (self.lc_messages or []) if isinstance(m, BaseMessage)]
-
-        if not msgs:
-            msgs = [SystemMessage(content=instruction_sys), SystemMessage(content=upload_placeholder)]
-            self.lc_messages = msgs
-            self._attach_stats_msg_idx = 1
-            return
-
-        if not isinstance(msgs[0], SystemMessage) or str(getattr(msgs[0], "content", "")).strip() != str(instruction_sys).strip():
-            msgs.insert(0, SystemMessage(content=instruction_sys))
-
-        def _is_upload_stats_msg(m: BaseMessage) -> bool:
-            if not isinstance(m, SystemMessage):
-                return False
-            return str(getattr(m, "content", "")).strip().startswith(UPLOAD_STATUS_SYSTEM_PREFIX)
-
-        if len(msgs) <= 1:
-            msgs.append(SystemMessage(content=upload_placeholder))
-        elif not _is_upload_stats_msg(msgs[1]):
-            found_idx = None
-            for i in range(2, len(msgs)):
-                if _is_upload_stats_msg(msgs[i]):
-                    found_idx = i
-                    break
-            if found_idx is not None:
-                m = msgs.pop(found_idx)
-                msgs.insert(1, m)
-            else:
-                msgs.insert(1, SystemMessage(content=upload_placeholder))
-
-        self.lc_messages = msgs
+        msgs = [m for m in (self.lc_messages or []) if isinstance(m, BaseMessage)]
+        self.lc_messages = self._apply_instruction_and_upload_headers(msgs, self.lang)
         self._attach_stats_msg_idx = 1
 
     def _close_unfinished_tool_calls_in_lc_messages(self) -> None:
@@ -1716,6 +1715,10 @@ class ChatSession:
         sess.history = list(data.get("history") or [])
         sess.chat_model_key = str(data.get("chat_model_key") or sess.chat_model_key)
         sess.vlm_model_key = str(data.get("vlm_model_key") or sess.vlm_model_key)
+        try:
+            sess.sent_media_total = int(data.get("sent_media_total", 0) or 0)
+        except Exception:
+            sess.sent_media_total = 0
         sess.load_media = cls._deserialize_load_media(data.get("load_media"))
 
         pending_ids = [str(x) for x in (data.get("pending_media_ids") or [])]
@@ -2038,6 +2041,7 @@ class ChatSession:
                 "media_count": len(self.load_media),
                 "pending_count": len(self.pending_media_ids),
                 "inflight_uploads": len(self.resumable_uploads),
+                "sent_media_total": int(getattr(self, "sent_media_total", 0) or 0),
             },
             "chat_model_key": self.chat_model_key,
             "chat_models": self.chat_models,
@@ -2228,10 +2232,19 @@ class SessionStore:
         if not _is_valid_session_id_hex(sid):
             return None
 
-        try:
-            restored = ChatSession.load_from_state(sid, self.cfg)
-        except SessionStateUnavailableError:
-            raise
+        restored: Optional[ChatSession] = None
+        delay = 0.05
+        for attempt in range(3):
+            try:
+                restored = ChatSession.load_from_state(sid, self.cfg)
+                break
+            except SessionStateUnavailableError as e:
+                reason = str(e.args[0]) if e.args else ""
+                if attempt < 2 and reason == "read_error":
+                    await asyncio.sleep(delay)
+                    delay *= 2.5
+                    continue
+                raise
         if restored is None:
             return None
         try:

--- a/agent_fastapi.py
+++ b/agent_fastapi.py
@@ -390,10 +390,17 @@ def _serialize_lc_message(msg: BaseMessage) -> Dict[str, Any]:
         return payload
     if isinstance(msg, AIMessage):
         ak = getattr(msg, "additional_kwargs", None) or {}
+        tc = getattr(msg, "tool_calls", None) or []
+        if not isinstance(tc, list):
+            tc = []
+        tc = _to_json_safe(tc)
+        if not isinstance(tc, list):
+            tc = []
         return {
             "type": "ai",
             "content": _to_json_safe(msg.content),
             "additional_kwargs": _to_json_safe(ak),
+            "tool_calls": tc,
         }
     return {
         "type": "unknown",
@@ -431,13 +438,20 @@ def _deserialize_lc_message(data: Dict[str, Any]) -> Optional[BaseMessage]:
         ak = data.get("additional_kwargs")
         if not isinstance(ak, dict):
             ak = {}
+        tc_explicit = data.get("tool_calls")
+        if isinstance(tc_explicit, list):
+            tool_calls = tc_explicit
+        else:
+            tool_calls = ak.get("tool_calls")
+        if not isinstance(tool_calls, list):
+            tool_calls = []
+        if tool_calls:
+            ak = dict(ak)
+            ak["tool_calls"] = tool_calls
         # Some providers (and langchain-core versions) require tool calls to be present
         # on the AIMessage object (not only inside additional_kwargs) in order to
         # produce a valid OpenAI-style messages list. Without this, ToolMessage
         # may become an "orphan" and providers will reject the request.
-        tool_calls = ak.get("tool_calls")
-        if not isinstance(tool_calls, list):
-            tool_calls = []
         try:
             return AIMessage(content=content, additional_kwargs=ak, tool_calls=tool_calls)  # type: ignore[arg-type]
         except TypeError:
@@ -1473,23 +1487,39 @@ class ChatSession:
         self._attach_stats_msg_idx = 1
 
     def _close_unfinished_tool_calls_in_lc_messages(self) -> None:
-        ai_ids: Set[str] = set()
-        result_ids: Set[str] = set()
-        for m in (self.lc_messages or []):
-            if isinstance(m, AIMessage):
-                ai_ids |= _tool_call_ids_from_ai_message_for_state(m)
-            elif isinstance(m, ToolMessage):
-                tcid = getattr(m, "tool_call_id", None)
-                if tcid:
-                    result_ids.add(str(tcid))
-
-        pending = sorted(ai_ids - result_ids)
-        if not pending:
-            return
-
+        msgs_in: List[BaseMessage] = [m for m in (self.lc_messages or []) if isinstance(m, BaseMessage)]
+        out: List[BaseMessage] = []
+        i = 0
+        n = len(msgs_in)
         cancelled_content = json.dumps({"cancelled": True, "cancelled_by_restart": True}, ensure_ascii=False)
-        for tcid in pending:
-            self.lc_messages.append(ToolMessage(content=cancelled_content, tool_call_id=str(tcid)))
+
+        while i < n:
+            m = msgs_in[i]
+            if not isinstance(m, AIMessage):
+                out.append(m)
+                i += 1
+                continue
+
+            out.append(m)
+            expected_ids = _tool_call_ids_from_ai_message_for_state(m)
+            responded_ids: Set[str] = set()
+            i += 1
+
+            # Preserve valid contiguous ToolMessages for this AI block.
+            while i < n and isinstance(msgs_in[i], ToolMessage):
+                tm = msgs_in[i]
+                tcid = str(getattr(tm, "tool_call_id", "") or "").strip()
+                if tcid and (tcid in expected_ids) and (tcid not in responded_ids):
+                    responded_ids.add(tcid)
+                    out.append(tm)
+                i += 1
+
+            # Inject cancelled results right after the originating AI block.
+            missing = sorted(expected_ids - responded_ids)
+            for tcid in missing:
+                out.append(ToolMessage(content=cancelled_content, tool_call_id=str(tcid)))
+
+        self.lc_messages = out
 
     def _sanitize_tool_protocol_in_lc_messages(self) -> None:
         """
@@ -1499,13 +1529,14 @@ class ChatSession:
         providers may reject requests with 400. We drop orphan ToolMessages here.
         """
         msgs_in: List[BaseMessage] = [m for m in (self.lc_messages or []) if isinstance(m, BaseMessage)]
+        msgs_out: List[BaseMessage] = []
         pending_ids: Set[str] = set()
         responded_ids: Set[str] = set()
-        msgs_out: List[BaseMessage] = []
 
         for m in msgs_in:
             if isinstance(m, AIMessage):
-                pending_ids |= _tool_call_ids_from_ai_message_for_state(m)
+                pending_ids = _tool_call_ids_from_ai_message_for_state(m)
+                responded_ids = set()
                 msgs_out.append(m)
                 continue
             if isinstance(m, ToolMessage):
@@ -1515,6 +1546,8 @@ class ChatSession:
                     msgs_out.append(m)
                 # else: drop orphan/duplicate tool message
                 continue
+            pending_ids = set()
+            responded_ids = set()
             msgs_out.append(m)
 
         self.lc_messages = msgs_out
@@ -1597,8 +1630,8 @@ class ChatSession:
         sess.tts_config = tts_cfg if isinstance(tts_cfg, dict) else {}
 
         sess._normalize_running_tool_records()
-        sess._sanitize_tool_protocol_in_lc_messages()
         sess._close_unfinished_tool_calls_in_lc_messages()
+        sess._sanitize_tool_protocol_in_lc_messages()
         sess._rebuild_tool_history_index()
         sess._ensure_lc_messages_invariants()
         return sess

--- a/agent_fastapi.py
+++ b/agent_fastapi.py
@@ -431,7 +431,17 @@ def _deserialize_lc_message(data: Dict[str, Any]) -> Optional[BaseMessage]:
         ak = data.get("additional_kwargs")
         if not isinstance(ak, dict):
             ak = {}
-        return AIMessage(content=content, additional_kwargs=ak)
+        # Some providers (and langchain-core versions) require tool calls to be present
+        # on the AIMessage object (not only inside additional_kwargs) in order to
+        # produce a valid OpenAI-style messages list. Without this, ToolMessage
+        # may become an "orphan" and providers will reject the request.
+        tool_calls = ak.get("tool_calls")
+        if not isinstance(tool_calls, list):
+            tool_calls = []
+        try:
+            return AIMessage(content=content, additional_kwargs=ak, tool_calls=tool_calls)  # type: ignore[arg-type]
+        except TypeError:
+            return AIMessage(content=content, additional_kwargs=ak)
     return None
 
 
@@ -1481,6 +1491,34 @@ class ChatSession:
         for tcid in pending:
             self.lc_messages.append(ToolMessage(content=cancelled_content, tool_call_id=str(tcid)))
 
+    def _sanitize_tool_protocol_in_lc_messages(self) -> None:
+        """
+        Ensure lc_messages won't violate OpenAI tool-calling protocol:
+        ToolMessage must correspond to a preceding AIMessage tool_call_id.
+        When restore/serialization fails to fully reconstruct tool_calls,
+        providers may reject requests with 400. We drop orphan ToolMessages here.
+        """
+        msgs_in: List[BaseMessage] = [m for m in (self.lc_messages or []) if isinstance(m, BaseMessage)]
+        pending_ids: Set[str] = set()
+        responded_ids: Set[str] = set()
+        msgs_out: List[BaseMessage] = []
+
+        for m in msgs_in:
+            if isinstance(m, AIMessage):
+                pending_ids |= _tool_call_ids_from_ai_message_for_state(m)
+                msgs_out.append(m)
+                continue
+            if isinstance(m, ToolMessage):
+                tcid = str(getattr(m, "tool_call_id", "") or "").strip()
+                if tcid and (tcid in pending_ids) and (tcid not in responded_ids):
+                    responded_ids.add(tcid)
+                    msgs_out.append(m)
+                # else: drop orphan/duplicate tool message
+                continue
+            msgs_out.append(m)
+
+        self.lc_messages = msgs_out
+
     def _normalize_running_tool_records(self) -> None:
         for rec in (self.history or []):
             if not isinstance(rec, dict):
@@ -1559,6 +1597,7 @@ class ChatSession:
         sess.tts_config = tts_cfg if isinstance(tts_cfg, dict) else {}
 
         sess._normalize_running_tool_records()
+        sess._sanitize_tool_protocol_in_lc_messages()
         sess._close_unfinished_tool_calls_in_lc_messages()
         sess._rebuild_tool_history_index()
         sess._ensure_lc_messages_invariants()
@@ -3010,6 +3049,9 @@ async def ws_chat(ws: WebSocket, session_id: str):
                         async def pump_agent():
                             nonlocal new_messages
                             try:
+                                # Guard: ensure the messages list won't violate tool protocol after restore.
+                                # This prevents provider-side 400 like: "Messages with role 'tool' must be a response..."
+                                sess._sanitize_tool_protocol_in_lc_messages()
                                 stream = sess.agent.astream(
                                     {"messages": _merged_messages},
                                     context=sess.client_context,

--- a/agent_fastapi.py
+++ b/agent_fastapi.py
@@ -72,6 +72,12 @@ CHUNK_SIZE = 1024 * 1024  # 1MB
 USE_SESSION_SUBDIR = True
 
 CUSTOM_MODEL_KEY = "__custom__"
+SESSION_STATE_FILENAME = "session_state.json"
+SESSION_STATE_MAX_HISTORY = 2000
+SESSION_STATE_MAX_LC_MESSAGES = 4000
+UPLOAD_STATUS_SYSTEM_PREFIX = "【User media upload status】"
+UPLOAD_STATUS_SYSTEM_EMPTY = "【User media upload status】{}"
+MASKED_SECRET = "***"
 
 def debug_traceback_print(cfg: Settings):
     if cfg.developer.developer_mode:
@@ -304,6 +310,164 @@ def detect_media_kind(filename: str) -> str:
     if ext in {".mp4", ".mov", ".avi", ".mkv", ".webm"}:
         return "video"
     return "unknown"
+
+
+_SECRET_VALUE_PATTERNS = [
+    re.compile(r"sk-[A-Za-z0-9._-]{16,}"),
+    re.compile(r"Bearer\s+[A-Za-z0-9._\-+/=]{16,}", re.IGNORECASE),
+    re.compile(r"eyJ[A-Za-z0-9_-]{16,}\.[A-Za-z0-9._-]{16,}\.?[A-Za-z0-9._-]*"),
+    re.compile(r"(?i)(?:api[_-]?key|access[_-]?token|refresh[_-]?token|authorization)\s*[:=]\s*[\"']?[A-Za-z0-9._\-+/=]{16,}[\"']?"),
+]
+
+
+def _mask_secret_string(text: str) -> str:
+    s = str(text or "")
+    for pat in _SECRET_VALUE_PATTERNS:
+        s = pat.sub(MASKED_SECRET, s)
+    return s
+
+
+def _to_json_safe(v: Any) -> Any:
+    if v is None or isinstance(v, (bool, int, float, str)):
+        return v
+    if isinstance(v, list):
+        return [_to_json_safe(x) for x in v]
+    if isinstance(v, tuple):
+        return [_to_json_safe(x) for x in v]
+    if isinstance(v, dict):
+        return {str(k): _to_json_safe(x) for k, x in v.items()}
+    try:
+        json.dumps(v, ensure_ascii=False)
+        return v
+    except Exception:
+        return str(v)
+
+
+def _mask_secrets_recursive(v: Any) -> Any:
+    if isinstance(v, dict):
+        out: Dict[str, Any] = {}
+        for k, val in v.items():
+            key = str(k)
+            if _is_secret_field_name(key):
+                out[key] = MASKED_SECRET
+            else:
+                out[key] = _mask_secrets_recursive(val)
+        return out
+    if isinstance(v, list):
+        return [_mask_secrets_recursive(x) for x in v]
+    if isinstance(v, tuple):
+        return [_mask_secrets_recursive(x) for x in v]
+    if isinstance(v, str):
+        return _mask_secret_string(v)
+    return _to_json_safe(v)
+
+
+def _mask_tool_history_record(rec: Dict[str, Any]) -> Dict[str, Any]:
+    r = dict(rec or {})
+    for key in ("args", "summary", "message"):
+        if key in r:
+            r[key] = _mask_secrets_recursive(r.get(key))
+    return r
+
+
+def _serialize_lc_message(msg: BaseMessage) -> Dict[str, Any]:
+    if isinstance(msg, SystemMessage):
+        return {"type": "system", "content": _to_json_safe(msg.content)}
+    if isinstance(msg, HumanMessage):
+        return {"type": "human", "content": _to_json_safe(msg.content)}
+    if isinstance(msg, ToolMessage):
+        payload = {
+            "type": "tool",
+            "content": _to_json_safe(msg.content),
+            "tool_call_id": str(getattr(msg, "tool_call_id", "") or ""),
+        }
+        ak = getattr(msg, "additional_kwargs", None)
+        if isinstance(ak, dict) and ak:
+            payload["additional_kwargs"] = _to_json_safe(ak)
+        name = getattr(msg, "name", None)
+        if name not in (None, ""):
+            payload["name"] = str(name)
+        return payload
+    if isinstance(msg, AIMessage):
+        ak = getattr(msg, "additional_kwargs", None) or {}
+        return {
+            "type": "ai",
+            "content": _to_json_safe(msg.content),
+            "additional_kwargs": _to_json_safe(ak),
+        }
+    return {
+        "type": "unknown",
+        "content": _to_json_safe(getattr(msg, "content", "")),
+    }
+
+
+def _deserialize_lc_message(data: Dict[str, Any]) -> Optional[BaseMessage]:
+    if not isinstance(data, dict):
+        return None
+    t = str(data.get("type") or "").strip().lower()
+    content = data.get("content", "")
+    if t == "system":
+        return SystemMessage(content=content)
+    if t == "human":
+        return HumanMessage(content=content)
+    if t == "tool":
+        tcid = str(data.get("tool_call_id") or "").strip()
+        if not tcid:
+            return None
+        kwargs: Dict[str, Any] = {}
+        ak = data.get("additional_kwargs")
+        if isinstance(ak, dict):
+            kwargs["additional_kwargs"] = ak
+        name = data.get("name")
+        if name not in (None, ""):
+            kwargs["name"] = str(name)
+        try:
+            return ToolMessage(content=content, tool_call_id=tcid, **kwargs)
+        except TypeError:
+            # Keep backward compatibility with signatures that do not accept `name`.
+            kwargs.pop("name", None)
+            return ToolMessage(content=content, tool_call_id=tcid, **kwargs)
+    if t == "ai":
+        ak = data.get("additional_kwargs")
+        if not isinstance(ak, dict):
+            ak = {}
+        return AIMessage(content=content, additional_kwargs=ak)
+    return None
+
+
+def _tool_call_ids_from_ai_message_for_state(m: BaseMessage) -> Set[str]:
+    ids: Set[str] = set()
+    if not isinstance(m, AIMessage):
+        return ids
+
+    tc = getattr(m, "tool_calls", None) or []
+    for c in tc:
+        _id = None
+        if isinstance(c, dict):
+            _id = c.get("id") or c.get("tool_call_id")
+        else:
+            _id = getattr(c, "id", None) or getattr(c, "tool_call_id", None)
+        if _id:
+            ids.add(str(_id))
+
+    ak = getattr(m, "additional_kwargs", None) or {}
+    tc2 = ak.get("tool_calls") or []
+    for c in tc2:
+        if isinstance(c, dict):
+            _id = c.get("id") or c.get("tool_call_id")
+            if _id:
+                ids.add(str(_id))
+    return ids
+
+
+def _is_valid_session_id_hex(name: str) -> bool:
+    if len(name) != 32:
+        return False
+    try:
+        val = uuid.UUID(name)
+        return val.hex == name and val.version == 4
+    except Exception:
+        return False
 
 _MEDIA_RE = re.compile(r"^media_(\d+)", re.IGNORECASE)
 
@@ -1095,7 +1259,7 @@ class ChatSession:
 
         self.lc_messages: List[BaseMessage] = [
             SystemMessage(content=get_prompt("instruction.system", lang=self.lang)),
-            SystemMessage(content="【User media upload status】{}"),
+            SystemMessage(content=UPLOAD_STATUS_SYSTEM_EMPTY),
         ]
         self.history: List[Dict[str, Any]] = []
 
@@ -1119,7 +1283,330 @@ class ChatSession:
         self._media_seq_inited = False
         self._media_seq_next = 1
 
+    @classmethod
+    def state_file_path_for(cls, session_id: str, cfg: Settings) -> str:
+        return os.path.abspath(os.path.join(str(cfg.project.outputs_dir), session_id, SESSION_STATE_FILENAME))
+
+    def state_file_path(self) -> str:
+        return self.state_file_path_for(self.session_id, self.cfg)
+
+    def _serialize_load_media(self) -> Dict[str, Dict[str, Any]]:
+        out: Dict[str, Dict[str, Any]] = {}
+        for mid, meta in (self.load_media or {}).items():
+            out[str(mid)] = {
+                "id": str(meta.id),
+                "name": str(meta.name),
+                "kind": str(meta.kind),
+                "path": str(meta.path),
+                "thumb_path": str(meta.thumb_path) if meta.thumb_path else None,
+                "ts": float(meta.ts),
+            }
+        return out
+
+    @staticmethod
+    def _deserialize_load_media(data: Any) -> Dict[str, MediaMeta]:
+        out: Dict[str, MediaMeta] = {}
+        if not isinstance(data, dict):
+            return out
+        for _k, v in data.items():
+            if not isinstance(v, dict):
+                continue
+            try:
+                meta = MediaMeta(
+                    id=str(v.get("id") or ""),
+                    name=str(v.get("name") or ""),
+                    kind=str(v.get("kind") or "unknown"),
+                    path=str(v.get("path") or ""),
+                    thumb_path=(str(v.get("thumb_path")) if v.get("thumb_path") else None),
+                    ts=float(v.get("ts") or time.time()),
+                )
+                if meta.id:
+                    out[meta.id] = meta
+            except Exception:
+                continue
+        return out
+
+    @staticmethod
+    def _sanitize_service_cfg_for_state(cfg_obj: Any) -> Any:
+        if cfg_obj is None:
+            return None
+        return _mask_secrets_recursive(_to_json_safe(cfg_obj))
+
+    @staticmethod
+    def _normalized_lc_messages_for_state(messages: List[BaseMessage], lang: str) -> List[BaseMessage]:
+        instruction_sys = get_prompt("instruction.system", lang=lang)
+        upload_placeholder = UPLOAD_STATUS_SYSTEM_EMPTY
+        msgs: List[BaseMessage] = [m for m in (messages or []) if isinstance(m, BaseMessage)]
+
+        if not msgs:
+            return [SystemMessage(content=instruction_sys), SystemMessage(content=upload_placeholder)]
+
+        if not isinstance(msgs[0], SystemMessage) or str(getattr(msgs[0], "content", "")).strip() != str(instruction_sys).strip():
+            msgs.insert(0, SystemMessage(content=instruction_sys))
+
+        def _is_upload_stats_msg(m: BaseMessage) -> bool:
+            if not isinstance(m, SystemMessage):
+                return False
+            return str(getattr(m, "content", "")).strip().startswith(UPLOAD_STATUS_SYSTEM_PREFIX)
+
+        if len(msgs) == 1:
+            msgs.append(SystemMessage(content=upload_placeholder))
+        elif not _is_upload_stats_msg(msgs[1]):
+            found_idx = None
+            for i in range(2, len(msgs)):
+                if _is_upload_stats_msg(msgs[i]):
+                    found_idx = i
+                    break
+            if found_idx is not None:
+                m = msgs.pop(found_idx)
+                msgs.insert(1, m)
+            else:
+                msgs.insert(1, SystemMessage(content=upload_placeholder))
+        return msgs
+
+    def _persist_history(self) -> List[Dict[str, Any]]:
+        out: List[Dict[str, Any]] = []
+        for item in (self.history or []):
+            if not isinstance(item, dict):
+                continue
+            rec = _to_json_safe(item)
+            if not isinstance(rec, dict):
+                continue
+            if str(rec.get("role") or "") == "tool":
+                rec = _mask_tool_history_record(rec)
+            out.append(rec)
+        if SESSION_STATE_MAX_HISTORY > 0 and len(out) > SESSION_STATE_MAX_HISTORY:
+            out = out[-SESSION_STATE_MAX_HISTORY:]
+        return out
+
+    def _serialize_lc_messages(self) -> List[Dict[str, Any]]:
+        msgs = self._normalized_lc_messages_for_state(list(self.lc_messages or []), self.lang)
+        if SESSION_STATE_MAX_LC_MESSAGES > 0 and len(msgs) > SESSION_STATE_MAX_LC_MESSAGES:
+            msgs = msgs[-SESSION_STATE_MAX_LC_MESSAGES:]
+            msgs = self._normalized_lc_messages_for_state(msgs, self.lang)
+            if len(msgs) > SESSION_STATE_MAX_LC_MESSAGES:
+                if SESSION_STATE_MAX_LC_MESSAGES <= 2:
+                    msgs = msgs[:SESSION_STATE_MAX_LC_MESSAGES]
+                else:
+                    # Keep invariant-critical first 2 system messages, trim tail payload.
+                    keep_tail = SESSION_STATE_MAX_LC_MESSAGES - 2
+                    msgs = msgs[:2] + msgs[-keep_tail:]
+
+        out: List[Dict[str, Any]] = []
+        for m in msgs:
+            try:
+                out.append(_serialize_lc_message(m))
+            except Exception:
+                continue
+        return out
+
+    def dump_state(self) -> Dict[str, Any]:
+        return {
+            "version": 1,
+            "session_id": self.session_id,
+            "lang": self.lang,
+            "history": self._persist_history(),
+            "chat_model_key": self.chat_model_key,
+            "vlm_model_key": self.vlm_model_key,
+            "load_media": self._serialize_load_media(),
+            "pending_media_ids": [str(x) for x in (self.pending_media_ids or [])],
+            "lc_messages_serialized": self._serialize_lc_messages(),
+            "pexels_key_mode": self.pexels_key_mode,
+            "custom_llm_config": self._sanitize_service_cfg_for_state(self.custom_llm_config),
+            "custom_vlm_config": self._sanitize_service_cfg_for_state(self.custom_vlm_config),
+            "tts_config": self._sanitize_service_cfg_for_state(self.tts_config),
+        }
+
+    def save_state_atomic(self) -> None:
+        path = self.state_file_path()
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        tmp = path + ".tmp"
+        data = self.dump_state()
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(data, f, ensure_ascii=False, indent=2)
+        os.replace(tmp, path)
+
+    def _ensure_lc_messages_invariants(self) -> None:
+        instruction_sys = get_prompt("instruction.system", lang=self.lang)
+        upload_placeholder = UPLOAD_STATUS_SYSTEM_EMPTY
+        msgs: List[BaseMessage] = [m for m in (self.lc_messages or []) if isinstance(m, BaseMessage)]
+
+        if not msgs:
+            msgs = [SystemMessage(content=instruction_sys), SystemMessage(content=upload_placeholder)]
+            self.lc_messages = msgs
+            self._attach_stats_msg_idx = 1
+            return
+
+        if not isinstance(msgs[0], SystemMessage) or str(getattr(msgs[0], "content", "")).strip() != str(instruction_sys).strip():
+            msgs.insert(0, SystemMessage(content=instruction_sys))
+
+        def _is_upload_stats_msg(m: BaseMessage) -> bool:
+            if not isinstance(m, SystemMessage):
+                return False
+            return str(getattr(m, "content", "")).strip().startswith(UPLOAD_STATUS_SYSTEM_PREFIX)
+
+        if len(msgs) <= 1:
+            msgs.append(SystemMessage(content=upload_placeholder))
+        elif not _is_upload_stats_msg(msgs[1]):
+            found_idx = None
+            for i in range(2, len(msgs)):
+                if _is_upload_stats_msg(msgs[i]):
+                    found_idx = i
+                    break
+            if found_idx is not None:
+                m = msgs.pop(found_idx)
+                msgs.insert(1, m)
+            else:
+                msgs.insert(1, SystemMessage(content=upload_placeholder))
+
+        self.lc_messages = msgs
+        self._attach_stats_msg_idx = 1
+
+    def _close_unfinished_tool_calls_in_lc_messages(self) -> None:
+        ai_ids: Set[str] = set()
+        result_ids: Set[str] = set()
+        for m in (self.lc_messages or []):
+            if isinstance(m, AIMessage):
+                ai_ids |= _tool_call_ids_from_ai_message_for_state(m)
+            elif isinstance(m, ToolMessage):
+                tcid = getattr(m, "tool_call_id", None)
+                if tcid:
+                    result_ids.add(str(tcid))
+
+        pending = sorted(ai_ids - result_ids)
+        if not pending:
+            return
+
+        cancelled_content = json.dumps({"cancelled": True, "cancelled_by_restart": True}, ensure_ascii=False)
+        for tcid in pending:
+            self.lc_messages.append(ToolMessage(content=cancelled_content, tool_call_id=str(tcid)))
+
+    def _normalize_running_tool_records(self) -> None:
+        for rec in (self.history or []):
+            if not isinstance(rec, dict):
+                continue
+            if str(rec.get("role") or "") != "tool":
+                continue
+            if str(rec.get("state") or "").lower() == "running":
+                rec["state"] = "error"
+                rec["progress"] = 1.0
+                rec["message"] = "Cancelled by restart"
+                rec["summary"] = {"cancelled": True, "cancelled_by_restart": True}
+
+    def _rebuild_tool_history_index(self) -> None:
+        self._tool_history_index = {}
+        for idx, rec in enumerate(self.history or []):
+            if not isinstance(rec, dict):
+                continue
+            if str(rec.get("role") or "") != "tool":
+                continue
+            tcid = rec.get("tool_call_id")
+            if tcid:
+                self._tool_history_index[str(tcid)] = idx
+
+    @classmethod
+    def load_from_state(cls, session_id: str, cfg: Settings) -> Optional["ChatSession"]:
+        path = cls.state_file_path_for(session_id, cfg)
+        if not os.path.exists(path):
+            return None
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            if not isinstance(data, dict):
+                return None
+            sid_in_file = str(data.get("session_id") or "").strip()
+            if sid_in_file and sid_in_file != session_id:
+                return None
+        except Exception:
+            return None
+
+        sess = cls(session_id=session_id, cfg=cfg)
+        sess.lang = str(data.get("lang") or "zh").strip().lower()
+        if sess.lang not in ("zh", "en"):
+            sess.lang = "zh"
+
+        sess.history = list(data.get("history") or [])
+        sess.chat_model_key = str(data.get("chat_model_key") or sess.chat_model_key)
+        sess.vlm_model_key = str(data.get("vlm_model_key") or sess.vlm_model_key)
+        sess.load_media = cls._deserialize_load_media(data.get("load_media"))
+
+        pending_ids = [str(x) for x in (data.get("pending_media_ids") or [])]
+        sess.pending_media_ids = [x for x in pending_ids if x in sess.load_media]
+
+        lc_msgs_raw = data.get("lc_messages_serialized") or []
+        lc_msgs: List[BaseMessage] = []
+        if isinstance(lc_msgs_raw, list):
+            for item in lc_msgs_raw:
+                try:
+                    msg = _deserialize_lc_message(item)
+                    if msg is not None:
+                        lc_msgs.append(msg)
+                except Exception:
+                    continue
+        sess.lc_messages = lc_msgs
+        sess._ensure_lc_messages_invariants()
+
+        sess.pexels_key_mode = str(data.get("pexels_key_mode") or "default").strip().lower()
+        if sess.pexels_key_mode not in ("default", "custom"):
+            sess.pexels_key_mode = "default"
+        sess.pexels_custom_key = ""
+
+        llm_cfg = data.get("custom_llm_config")
+        sess.custom_llm_config = llm_cfg if isinstance(llm_cfg, dict) else None
+        vlm_cfg = data.get("custom_vlm_config")
+        sess.custom_vlm_config = vlm_cfg if isinstance(vlm_cfg, dict) else None
+        tts_cfg = data.get("tts_config")
+        sess.tts_config = tts_cfg if isinstance(tts_cfg, dict) else {}
+
+        sess._normalize_running_tool_records()
+        sess._close_unfinished_tool_calls_in_lc_messages()
+        sess._rebuild_tool_history_index()
+        sess._ensure_lc_messages_invariants()
+        return sess
+
+    def _missing_secret_config_fields(self) -> List[str]:
+        missing: List[str] = []
+
+        def _is_missing(v: Any) -> bool:
+            s = str(v or "").strip()
+            return (not s) or s == MASKED_SECRET
+
+        if self.chat_model_key == CUSTOM_MODEL_KEY:
+            cfg = self.custom_llm_config if isinstance(self.custom_llm_config, dict) else {}
+            if _is_missing(cfg.get("model")) or _is_missing(cfg.get("base_url")) or _is_missing(cfg.get("api_key")):
+                missing.append("custom_llm")
+
+        if self.vlm_model_key == CUSTOM_MODEL_KEY:
+            cfg = self.custom_vlm_config if isinstance(self.custom_vlm_config, dict) else {}
+            if _is_missing(cfg.get("model")) or _is_missing(cfg.get("base_url")) or _is_missing(cfg.get("api_key")):
+                missing.append("custom_vlm")
+
+        if (self.pexels_key_mode or "").lower() == "custom":
+            if _is_missing(self.pexels_custom_key):
+                missing.append("pexels_custom")
+
+        tts_cfg = self.tts_config if isinstance(self.tts_config, dict) else {}
+        provider = str(tts_cfg.get("provider") or "").strip().lower()
+        if provider:
+            block = tts_cfg.get(provider)
+            if not isinstance(block, dict):
+                missing.append(f"tts:{provider}")
+            else:
+                has_secret_key = False
+                miss_secret = False
+                for k, v in block.items():
+                    if _is_secret_field_name(str(k)):
+                        has_secret_key = True
+                        if _is_missing(v):
+                            miss_secret = True
+                if has_secret_key and miss_secret:
+                    missing.append(f"tts:{provider}")
+
+        return sorted(set(missing))
+
     def _ensure_system_prompt(self) -> None:
+        # Keep the instruction system prompt and upload-status placeholder stable.
+        self._ensure_lc_messages_invariants()
         sys = (get_prompt("instruction.system", lang=self.lang) or "").strip()
         if not sys:
             return
@@ -1227,6 +1714,13 @@ class ChatSession:
         return True, None
 
     async def ensure_agent(self) -> None:
+        missing = self._missing_secret_config_fields()
+        if missing:
+            raise RuntimeError(
+                "requires_reconfig: custom llm/vlm/tts/pexels secrets missing after restart; "
+                f"missing={','.join(missing)}"
+            )
+
         # 1) resolve LLM override
         if self.chat_model_key == CUSTOM_MODEL_KEY:
             if not isinstance(self.custom_llm_config, dict):
@@ -1514,17 +2008,45 @@ class SessionStore:
         sess = ChatSession(sid, self.cfg)
         async with self._lock:
             self._sessions[sid] = sess
+        await self.save_session_state(sess)
         return sess
 
     async def get(self, sid: str) -> Optional[ChatSession]:
         async with self._lock:
-            return self._sessions.get(sid)
+            sess = self._sessions.get(sid)
+            if sess is not None:
+                return sess
+
+        sid = str(sid or "").strip()
+        if not _is_valid_session_id_hex(sid):
+            return None
+
+        restored = ChatSession.load_from_state(sid, self.cfg)
+        if restored is None:
+            return None
+        try:
+            restored.save_state_atomic()
+        except Exception:
+            pass
+
+        async with self._lock:
+            existing = self._sessions.get(sid)
+            if existing is not None:
+                return existing
+            self._sessions[sid] = restored
+            return restored
 
     async def get_or_404(self, sid: str) -> ChatSession:
         sess = await self.get(sid)
         if not sess:
             raise HTTPException(status_code=404, detail="session not found")
         return sess
+
+    async def save_session_state(self, sess: ChatSession) -> None:
+        try:
+            sess.save_state_atomic()
+        except Exception as e:
+            logger.warning("failed to persist session state. sid=%s err=%s", getattr(sess, "session_id", "?"), e)
 
 
 @asynccontextmanager
@@ -1586,15 +2108,21 @@ async def _enforce_upload_media_count_limit(request: Request, cost: float) -> Op
 
 _TTS_UI_SECRET_KEYS = {
     "api_key",
+    "api-token",
+    "api_token",
+    "auth_token",
     "access_token",
     "authorization",
     "token",
     "password",
     "secret",
+    "client_secret",
+    "refresh_token",
     "x-api-key",
     "apikey",
     "access_key",
     "accesskey",
+    "pexels_api_key",
 }
 
 _PROVIDER_UI_META_KEYS = {
@@ -1782,13 +2310,14 @@ async def clear_session_chat(session_id: str):
         sess._attach_stats_msg_idx = 1
         sess.lc_messages = [
             SystemMessage(content=get_prompt("instruction.system", lang=sess.lang)),
-            SystemMessage(content="【User media upload status】{}"),
+            SystemMessage(content=UPLOAD_STATUS_SYSTEM_EMPTY),
         ]
         sess._attach_stats_msg_idx = 1
 
         sess.history = []
         sess._tool_history_index = {}
         clear_ai_transition_cancelled(_ai_transition_cancel_cache_root(app.state.cfg), session_id)
+        await store.save_session_state(sess)
     return JSONResponse({"ok": True})
 
 @api.post("/sessions/{session_id}/cancel")
@@ -1844,6 +2373,8 @@ async def upload_media(session_id: str, request: Request, files: List[UploadFile
         finally:
             async with sess.media_lock:
                 sess._direct_upload_reservations = max(0, sess._direct_upload_reservations - n)
+
+        await store.save_session_state(sess)
 
         return JSONResponse({
             "media": [sess.public_media(m) for m in metas],
@@ -2027,6 +2558,8 @@ async def complete_resumable_media_upload(session_id: str, upload_id: str):
             sess.load_media[meta.id] = meta
             sess.pending_media_ids.append(meta.id)
 
+        await store.save_session_state(sess)
+
         return JSONResponse({
             "media": sess.public_media(meta),
             "pending_media": sess.public_pending_media(),
@@ -2071,6 +2604,7 @@ async def delete_pending_media(session_id: str, media_id: str):
     store: SessionStore = app.state.sessions
     sess = await store.get_or_404(session_id)
     await sess.delete_pending_media(media_id)
+    await store.save_session_state(sess)
     return JSONResponse({"ok": True, "pending_media": sess.public_pending_media()})
 
 
@@ -2273,6 +2807,7 @@ async def ws_chat(ws: WebSocket, session_id: str):
                     if sess.client_context:
                         sess.client_context.lang = lang
 
+                    await store.save_session_state(sess)
                     await ws_send(ws, "session.lang", {"lang": lang})
                     continue
 
@@ -2282,11 +2817,12 @@ async def ws_chat(ws: WebSocket, session_id: str):
                         sess._attach_stats_msg_idx = 1
                         sess.lc_messages = [
                             SystemMessage(content=get_prompt("instruction.system", lang=sess.lang)),
-                            SystemMessage(content="【User media upload status】{}"),
+                            SystemMessage(content=UPLOAD_STATUS_SYSTEM_EMPTY),
                         ]
                         sess._attach_stats_msg_idx = 1
                         sess.history = []
                         sess._tool_history_index = {}
+                        await store.save_session_state(sess)
                     await ws_send(ws, "chat.cleared", {"ok": True})
                     continue
 
@@ -2428,6 +2964,7 @@ async def ws_chat(ws: WebSocket, session_id: str):
                         }
                         sess.history.append(user_msg)
                         sess.lc_messages.append(HumanMessage(content=prompt))
+                        await store.save_session_state(sess)
 
                         if app.state.cfg.developer.print_context:
                             print("[LLM_CTX]", session_id, sess.lc_messages, flush=True)
@@ -2814,6 +3351,7 @@ async def ws_chat(ws: WebSocket, session_id: str):
                                         # ★打断：只发 assistant.end，带 interrupted=true
                                         await emit_turn_event("assistant.end", {"text": interrupted_text, "interrupted": True})
 
+                                        await store.save_session_state(sess)
                                         sess.cancel_event.clear()
                                         break
 
@@ -2877,6 +3415,7 @@ async def ws_chat(ws: WebSocket, session_id: str):
                                             sess.lc_messages.extend(new_messages)
 
                                         await emit_turn_event("assistant.end", {"text": final_text})
+                                        await store.save_session_state(sess)
                                         break
 
                                     if kind == "agent.error":
@@ -2898,6 +3437,7 @@ async def ws_chat(ws: WebSocket, session_id: str):
 
                                         # ★ 真异常：只发 error（并带 partial_text 让前端结束当前气泡）
                                         await emit_turn_event("error", {"message": err_text, "partial_text": partial})
+                                        await store.save_session_state(sess)
                                         break
                         
                         except WebSocketDisconnect:

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -487,6 +487,26 @@ function __applyLang(lang, { persist = true } = {}) {
 })();
 
 
+/** Thrown by ApiClient for HTTP failures; callers use `status` (e.g. 404 vs transient). */
+class HttpError extends Error {
+  constructor(message, status) {
+    super(message);
+    this.name = "HttpError";
+    this.status = status;
+  }
+}
+
+/** GET /api/sessions/:id — 404 means this id is not valid on the server; safe to drop local pointer. */
+function isSessionNotFoundError(err) {
+  return !!(err && err.status === 404);
+}
+
+/** Network failure or 5xx (incl. 503 session state unavailable); may retry — not "session gone". */
+function isRetryableSessionLoadError(err) {
+  const st = err && err.status;
+  return st == null || st === 0 || (Number(st) >= 500 && Number(st) < 600);
+}
+
 class ApiClient {
   async createSession() {
     const r = await fetch("/api/sessions", { method: "POST" });
@@ -497,9 +517,7 @@ class ApiClient {
   async getSession(sessionId) {
     const r = await fetch(`/api/sessions/${encodeURIComponent(sessionId)}`);
     if (!r.ok) {
-      const err = new Error(await this._readFetchError(r));
-      err.status = r.status;
-      throw err;
+      throw new HttpError(await this._readFetchError(r), r.status);
     }
     return await r.json();
   }
@@ -2501,6 +2519,41 @@ class App {
     return `${proto}://${location.host}/ws/sessions/${encodeURIComponent(sessionId)}/chat`;
   }
 
+  /**
+   * Restore `saved` session id from the server. Retries transient failures so a short
+   * network blip does not immediately fall through to `newSession()` (which would
+   * overwrite SESSION_ID_KEY with a new id).
+   * @returns {Promise<boolean>} true if session was restored
+   */
+  async _bootstrapRestoreSavedSession(saved) {
+    const maxAttempts = 3;
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      try {
+        const snap = await this.api.getSession(saved);
+        await this.useSession(saved, snap);
+        return true;
+      } catch (err) {
+        if (isSessionNotFoundError(err)) {
+          localStorage.removeItem(SESSION_ID_KEY);
+          this._removeSessionFromHistory(saved);
+          this._renderSessionHistory();
+          return false;
+        }
+        if (attempt < maxAttempts - 1 && isRetryableSessionLoadError(err)) {
+          await new Promise((r) => setTimeout(r, 400 * (attempt + 1)));
+          continue;
+        }
+        console.warn(
+          "[session] failed to restore saved session (non-404), keep local record:",
+          saved,
+          err
+        );
+        return false;
+      }
+    }
+    return false;
+  }
+
   async bootstrap() {
     // this.restoreSidebarState();
     // this.restoreDevbarState();
@@ -2517,20 +2570,8 @@ class App {
     // 复用 localStorage 当前会话；如果失效就创建新 session
     const saved = localStorage.getItem(SESSION_ID_KEY);
     if (saved) {
-      try {
-        const snap = await this.api.getSession(saved);
-        await this.useSession(saved, snap);
-        return;
-      } catch (err) {
-        // 仅当明确 404（会话不存在）时才清理本地记录；其它错误（例如网络抖动）不要误删
-        if (err && err.status === 404) {
-          localStorage.removeItem(SESSION_ID_KEY);
-          this._removeSessionFromHistory(saved);
-          this._renderSessionHistory();
-        } else {
-          console.warn("[session] failed to restore saved session (non-404), keep local record:", saved, err);
-        }
-      }
+      const restored = await this._bootstrapRestoreSavedSession(saved);
+      if (restored) return;
     }
 
     await this.newSession();
@@ -3609,7 +3650,7 @@ class App {
         } catch (err) {
           console.warn("[session] failed to restore session", sid, err);
           // 仅当明确 404（会话不存在）时才清理本地记录；其它错误不要误删
-          if (err && err.status === 404) {
+          if (isSessionNotFoundError(err)) {
             this._handleMissingSessionOnClick(sid);
             return;
           }
@@ -3955,7 +3996,7 @@ class App {
       } catch (e) {
         console.warn("[session] failed to reuse blank session, will create new one:", e);
         // 仅当明确 404 时才清理本地记录；其它错误不要误删
-        if (e && e.status === 404) {
+        if (isSessionNotFoundError(e)) {
           this._removeSessionFromHistory(blankId);
           this._renderSessionHistory(this.sessionId);
         }

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -113,6 +113,7 @@ const __OS_I18N = {
     "toast.delete_failed": "删除失败：{msg}",
     "toast.uploading_cannot_send": "素材正在上传中，上传完成后才能发送。",
     "toast.switch_while_streaming": "正在生成回复，暂时无法切换会话。请先等待完成或打断当前回复。",
+    "toast.session_restore_unavailable": "暂时无法从服务器恢复会话（网络或服务繁忙）。请稍后刷新或重试；本地会话 ID 已保留。",
     "toast.uploading_interrupt_send": "素材正在上传中，暂时无法发送新消息。已为你打断当前回复；上传完成后再按 Enter 发送。",
     "toast.media_all_filtered": "仅支持上传视频或图片文件。",
     "toast.media_partial_filtered": "已过滤 {n} 个不支持的文件类型，仅上传视频/图片。",
@@ -236,6 +237,7 @@ const __OS_I18N = {
     "toast.delete_failed": "Delete failed: {msg}",
     "toast.uploading_cannot_send": "Media is uploading. Please wait until it finishes before sending.",
     "toast.switch_while_streaming": "A reply is still being generated. Please wait or interrupt before switching chats.",
+    "toast.session_restore_unavailable": "Could not restore the session from the server (network or temporary overload). Please retry later or refresh. Your local session id is kept.",
     "toast.uploading_interrupt_send": "Media is uploading, so a new message can't be sent yet. I interrupted the current reply; press Enter after the upload finishes.",
     "toast.media_all_filtered": "Only video or image files are supported.",
     "toast.media_partial_filtered": "{n} unsupported file(s) were filtered; only video/image files will be uploaded.",
@@ -501,10 +503,13 @@ function isSessionNotFoundError(err) {
   return !!(err && err.status === 404);
 }
 
-/** Network failure or 5xx (incl. 503 session state unavailable); may retry — not "session gone". */
+/** Network failure, 429, or 5xx (incl. 503 session state unavailable); may retry — not "session gone". */
 function isRetryableSessionLoadError(err) {
   const st = err && err.status;
-  return st == null || st === 0 || (Number(st) >= 500 && Number(st) < 600);
+  if (st == null || st === 0) return true;
+  if (Number(st) === 429) return true;
+  if (Number(st) >= 500 && Number(st) < 600) return true;
+  return false;
 }
 
 class ApiClient {
@@ -2523,21 +2528,23 @@ class App {
    * Restore `saved` session id from the server. Retries transient failures so a short
    * network blip does not immediately fall through to `newSession()` (which would
    * overwrite SESSION_ID_KEY with a new id).
-   * @returns {Promise<boolean>} true if session was restored
+   * @returns {Promise<'restored'|'missing'|'unavailable'>}
    */
   async _bootstrapRestoreSavedSession(saved) {
     const maxAttempts = 3;
+    let lastErr = null;
     for (let attempt = 0; attempt < maxAttempts; attempt++) {
       try {
         const snap = await this.api.getSession(saved);
         await this.useSession(saved, snap);
-        return true;
+        return "restored";
       } catch (err) {
+        lastErr = err;
         if (isSessionNotFoundError(err)) {
           localStorage.removeItem(SESSION_ID_KEY);
           this._removeSessionFromHistory(saved);
           this._renderSessionHistory();
-          return false;
+          return "missing";
         }
         if (attempt < maxAttempts - 1 && isRetryableSessionLoadError(err)) {
           await new Promise((r) => setTimeout(r, 400 * (attempt + 1)));
@@ -2548,10 +2555,11 @@ class App {
           saved,
           err
         );
-        return false;
+        return "unavailable";
       }
     }
-    return false;
+    console.warn("[session] restore exhausted retries, keep local record:", saved, lastErr);
+    return "unavailable";
   }
 
   async bootstrap() {
@@ -2570,8 +2578,22 @@ class App {
     // 复用 localStorage 当前会话；如果失效就创建新 session
     const saved = localStorage.getItem(SESSION_ID_KEY);
     if (saved) {
-      const restored = await this._bootstrapRestoreSavedSession(saved);
-      if (restored) return;
+      const st = await this._bootstrapRestoreSavedSession(saved);
+      if (st === "restored") return;
+      if (st === "unavailable") {
+        if (this.ui && this.ui.showToastI18n) {
+          this.ui.showToastI18n("toast.session_restore_unavailable", {});
+          setTimeout(() => {
+            try {
+              this.ui.hideToast();
+            } catch {}
+          }, 4500);
+        }
+        const lang = __osNormLang(this.lang || "zh");
+        await this.useSession(saved, { history: [], lang, pending_media: [] });
+        this._scheduleRecoveryPoll(600);
+        return;
+      }
     }
 
     await this.newSession();


### PR DESCRIPTION

### Summary
我重新提交并收敛了 PR #75「会话状态落盘与重启恢复」相关能力，并严格按维护者 review 的三点建议补齐边界与兜底策略。该 PR **只包含 2 个文件的修改**：`agent_fastapi.py`、`web/static/app.js`。

### Why PR #75 was closed
原 PR #75 后期为了对齐上游与 UI/配置结构，混入了几次与“会话持久化主线”无关的提交（例如 merge upstream、补配置 schema、UI adopt）。这些混入提交随后在关闭前集中 revert，导致 PR 变更范围失焦、难以 review/merge，因此 PR #75 选择关闭并建议后续以更清晰的范围重提。  


## What changed
### 1) 会话状态落盘与重启恢复（延续 PR#75 主线）
- 支持会话状态落盘与懒恢复，保障重启后同一 `session_id` 可继续使用。
- 保持 `503 vs 404` 语义边界：状态文件不可读/损坏 → 503；会话不存在/不匹配 → 404。

### 2) 我如何落实维护者提出的三点建议
#### 建议 1：脱敏不应只依赖 regex；应在配置结构体层面避免序列化 raw key
- 我把“主边界”前移到 **持久化结构体层面**：落盘时对 `custom_llm_config/custom_vlm_config` 进行结构化裁剪，**保证 raw key 不会被序列化进状态文件**。
- 同时保留原有的递归脱敏（regex/关键词匹配）作为**兜底**，用于覆盖 `history/tool payload` 等非结构化字符串路径。

#### 建议 2：坏掉的 `session_state.json` 处理策略（503 vs 404）
- 我维持并强化了该边界：读/解析失败 → 503；缺失/不匹配 → 404，使客户端能正确区分“可重试”与“确实不存在”。

#### 建议 3：ToolMessage 丢 `tool_call_id` 时不要只 warning；应 fail-closed，并显式 degraded
- 我实现了 **fail-closed**：一旦恢复时发现 `ToolMessage` 缺失 `tool_call_id` 或 tool 协议不一致，会从其所属的 tool-use turn 起截断后续 `lc_messages`，避免把语义可能错配的 tool 结果继续喂给 LLM。
- 同时我把降级状态 **显式暴露给上层**：在 session snapshot 中返回 `restore_degraded` / `restore_degraded_reason`，便于前端或调用方提示用户“部分历史未恢复”。

---

## Test plan（全链路）
我做了全链路验证并覆盖了以下场景：
- `custom_llm_config` 脱敏（通过）
- TTS 配置脱敏（通过）
- 递归脱敏兜底能力（通过）
- 状态文件读写（通过）
- 损坏状态文件（503/404 边界正确）（通过）
- ToolMessage（有效/损坏/缺失）处理（通过）
- 边界情况（None/空字典/部分配置）（通过）
- 完整工作流（含损坏场景检测）（通过）
